### PR TITLE
Add background color to avatars

### DIFF
--- a/components/card-avatar.tsx
+++ b/components/card-avatar.tsx
@@ -26,7 +26,7 @@ const CardAvatar = (props: CardAvatarProps) => {
 
   return (
     <img
-      className={`h-48 w-48 border-4 object-cover rounded ${floatClass}`}
+      className={`h-48 w-48 border-4 bg-slate-100 dark:bg-slate-800 object-cover rounded ${floatClass}`}
       src={resizedAvatarURL}
       alt={(name && `Avatar for ${name}`) || ''}
       style={{


### PR DESCRIPTION
This is necessary to ensure that sections with fenced code blocks do not result in a two-tone
background color for avatars that overlap with them.

Resolves item 2 of #179.

Thanks for the suggestion, [Dragon Nest](https://github.com/H077y)!